### PR TITLE
Fix GDT issues

### DIFF
--- a/source-code/x86_64/0.6/src/x86_64/gdt.c
+++ b/source-code/x86_64/0.6/src/x86_64/gdt.c
@@ -15,7 +15,7 @@
 extern void gdt_flush(gdtr_t *gdtr_instance);
 extern void reloadSegments();
 
-gdt_entry_t gdt_entries[5];
+gdt_entry_t gdt_entries[7];
 gdtr_t gdtr_instance;
 
 void gdt_setup( uint8_t idx, uint64_t base, uint32_t limit, uint8_t access, uint8_t granularity){
@@ -35,12 +35,15 @@ void gdt_setup_sysseg( uint8_t idx, uint64_t base, uint32_t limit, uint8_t acces
 
     // Setup the following GDT entry with the upper 32 bits of the base and zero upper 32bits
     // that are reserved.
-    gdt_entries[idx+1].limit_low  = (base >> 32) & 0xFFFF; // lower 16 bits of the upper 32 bits of base
-    gdt_entries[idx+1].base_low   = (base >> 48) & 0xFFFF; // upper 16 bits of the upper 32 bits of base
-    gdt_entries[idx+1].base_middle  = 0;                   // Set the rest of fields to 0 (reserved)
-    gdt_entries[idx+1].access       = 0;
-    gdt_entries[idx+1].granularity  = 0;
-    gdt_entries[idx+1].base_high    = 0;
+    gdt_setup(idx + 1, (base >> 48) & 0xffff , (base >> 32) & 0xffff, 0, 0);
+
+    // The line above is equivalent to:
+    // gdt_entries[idx+1].limit_low  = (base >> 32) & 0xFFFF; // lower 16 bits of the upper 32 bits of base
+    // gdt_entries[idx+1].base_low   = (base >> 48) & 0xFFFF; // upper 16 bits of the upper 32 bits of base
+    // gdt_entries[idx+1].base_middle  = 0;                   // Set the rest of fields to 0 (reserved)
+    // gdt_entries[idx+1].access       = 0;
+    // gdt_entries[idx+1].granularity  = 0;
+    // gdt_entries[idx+1].base_high    = 0;
 }
 
 

--- a/source-code/x86_64/0.6/src/x86_64/gdt.c
+++ b/source-code/x86_64/0.6/src/x86_64/gdt.c
@@ -15,7 +15,7 @@
 extern void gdt_flush(gdtr_t *gdtr_instance);
 extern void reloadSegments();
 
-gdt_entry_t gdt_entries[7];
+gdt_entry_t gdt_entries[5];
 gdtr_t gdtr_instance;
 
 void gdt_setup( uint8_t idx, uint64_t base, uint32_t limit, uint8_t access, uint8_t granularity){

--- a/source-code/x86_64/0.6/src/x86_64/gdt.c
+++ b/source-code/x86_64/0.6/src/x86_64/gdt.c
@@ -33,6 +33,8 @@ void gdt_setup_sysseg( uint8_t idx, uint64_t base, uint32_t limit, uint8_t acces
     // First half of a system segment is the same as a regular segment
     gdt_setup(idx, base, limit, access, granularity);
 
+    // Setup the following GDT entry with the upper 32 bits of the base and zero upper 32bits
+    // that are reserved.
     gdt_entries[idx+1].limit_low  = (base >> 32) & 0xFFFF; // lower 16 bits of the upper 32 bits of base
     gdt_entries[idx+1].base_low   = (base >> 48) & 0xFFFF; // upper 16 bits of the upper 32 bits of base
     gdt_entries[idx+1].base_middle  = 0;                   // Set the rest of fields to 0 (reserved)

--- a/source-code/x86_64/0.6/src/x86_64/gdt.c
+++ b/source-code/x86_64/0.6/src/x86_64/gdt.c
@@ -30,7 +30,7 @@ void gdt_setup( uint8_t idx, uint64_t base, uint32_t limit, uint8_t access, uint
 
 // Version to create TSS and LGDT entries which require 2 GDT entries
 void gdt_setup_sysseg( uint8_t idx, uint64_t base, uint32_t limit, uint8_t access, uint8_t granularity){
-    // First hald of a system segment is the same as a regular segment
+    // First half of a system segment is the same as a regular segment
     gdt_setup(idx, base, limit, access, granularity);
 
     gdt_entries[idx+1].limit_low  = (base >> 32) & 0xFFFF; // lower 16 bits of the upper 32 bits of base

--- a/source-code/x86_64/0.6/src/x86_64/gdt.c
+++ b/source-code/x86_64/0.6/src/x86_64/gdt.c
@@ -30,17 +30,12 @@ void gdt_setup( uint8_t idx, uint64_t base, uint32_t limit, uint8_t access, uint
 
 // Version to create TSS and LGDT entries which require 2 GDT entries
 void gdt_setup_sysseg( uint8_t idx, uint64_t base, uint32_t limit, uint8_t access, uint8_t granularity){
-    gdt_entries[idx].limit_low    = limit & 0xFFFF;       // 16 bit
-    gdt_entries[idx].base_low     = base  & 0xFFFF;       // 16 bit
-    gdt_entries[idx].base_middle  = (base >> 16) & 0xFF;  // 8 bit
-    gdt_entries[idx].access       = access;
-    gdt_entries[idx].granularity  = (limit >> 16) & 0x0F; // Set limit : lower 4 bit
-    gdt_entries[idx].granularity |= granularity & 0xF0;   // Set Flags : upper 4 bit
-    gdt_entries[idx].base_high    = (base >> 24) & 0xFF;       // 8 bit
+    // First hald of a system segment is the same as a regular segment
+    gdt_setup(idx, base, limit, access, granularity);
 
-    gdt_entries[idx+1].limit_low  = (base >> 32) & 0xFFFF; // 16 bit
-    gdt_entries[idx+1].base_low   = (base >> 48) & 0xFFFF; // 16 bit
-    gdt_entries[idx+1].base_middle  = 0;
+    gdt_entries[idx+1].limit_low  = (base >> 32) & 0xFFFF; // lower 16 bits of the upper 32 bits of base
+    gdt_entries[idx+1].base_low   = (base >> 48) & 0xFFFF; // upper 16 bits of the upper 32 bits of base
+    gdt_entries[idx+1].base_middle  = 0;                   // Set the rest of fields to 0 (reserved)
     gdt_entries[idx+1].access       = 0;
     gdt_entries[idx+1].granularity  = 0;
     gdt_entries[idx+1].base_high    = 0;

--- a/source-code/x86_64/0.6/src/x86_64/gdt.h
+++ b/source-code/x86_64/0.6/src/x86_64/gdt.h
@@ -8,18 +8,15 @@
 
 
 struct gdt_entry
-{// 128 Bit
+{// 64-Bit
     uint16_t limit_low;       // Lower 16 bits of the segment limit
     uint16_t base_low;        // Lower 16 bits of the base address
     uint8_t base_middle;      // Next 8 bits of the base address
     uint8_t access;           // Access byte
     uint8_t granularity;      // Flags and upper limit
     uint8_t base_high;        // Next 8 bits of the base address
-    uint32_t base_upper;      // Upper 32 bits of the base address
-    uint32_t reserved;        // Reserved (must be zero)
 } __attribute__((packed));
 typedef struct gdt_entry gdt_entry_t;
-
 
 // Structure for GDTR
 struct gdtr {

--- a/source-code/x86_64/0.6/src/x86_64/gdt.h
+++ b/source-code/x86_64/0.6/src/x86_64/gdt.h
@@ -27,6 +27,7 @@ typedef struct gdtr gdtr_t;
 
 
 void gdt_setup( uint8_t idx, uint64_t base, uint32_t limit, uint8_t access, uint8_t granularity);
+void gdt_setup_sysseg( uint8_t idx, uint64_t base, uint32_t limit, uint8_t access, uint8_t granularity);
 void init_gdt();
 void check_gdt();
 

--- a/source-code/x86_64/0.6/src/x86_64/gdt.s
+++ b/source-code/x86_64/0.6/src/x86_64/gdt.s
@@ -5,8 +5,7 @@
 section .text
 global gdt_flush
 gdt_flush:
-   MOV RAX, [RDI]
-   LGDT  [RAX]
+   LGDT  [RDI]
    RET
 
 
@@ -16,7 +15,7 @@ reloadSegments:
    PUSH 0x08                 ; Push code segment to stack, 0x08 is a stand-in for your code segment
    LEA RAX, [rel reload_CS]  ; Load address of reload_CS into RAX, LEA (Load Effective Address), 
    PUSH RAX                  ; Push this value to the stack
-   LRETQ                     ; Perform a far return, RETFQ or LRETQ depending on syntax
+   RETFQ                     ; Perform a far return, RETFQ or LRETQ depending on syntax
 
 
 reload_CS:
@@ -28,5 +27,4 @@ reload_CS:
    MOV   GS, AX
    MOV   SS, AX
    RET
-   
-   
+


### PR DESCRIPTION
- `gdt_flush` was doing a level of indirection it shouldn't have which resulted in a bogus address being used by `LGDT`
- GDT entries in long mode are 64-bit (8 byte) except for system segments (TSS and LDT entries) which are 128-bit (16 bytes).
- Create a new function `gdt_setup_sysseg` to create a TSS or LDT entry that span 2 consecutive 8 byte GDT entries. This can be cleaned up and made easier to maintain in C11 (which you are using) if you make `gdt_entry_t` a union of anonymous structs.
- In NASM syntax `LRETQ` needs to be `RETFQ` in `reloadSegments`. This fixes an exception caused by the return not being generated. `LRETQ` is treated as a label and not an instruction by NASM. This was also the cause of a warning during assembling similar to `src/x86_64/gdt.s:18: warning: label alone on a line without a colon might be in error [-w+label-orphan]`
- Other minor cleanup.
