### PR TITLE
Cleanup gdt.c and gdt.h to simplify code

### DIFF
--- a/src/x86_64/gdt/gdt.c
+++ b/src/x86_64/gdt/gdt.c
@@ -44,11 +44,7 @@ void start_bootstrap_gdt_tss() {
         return;
     }
 
-    gdt_flush((gdtr_t *) &bootstrap.gdtr);
-    // printf("gdt flush completed.\n");
-
-    tss_flush(0x28);
-    // printf("tss flush completed.\n");
+    load_gdt_tss(&bootstrap);
 
     printf("Successfully started GDT and TSS for Bootstrap CPU.\n");
 }
@@ -106,6 +102,14 @@ void init_gdt_tss(cpu_data_t *core) {
 
 }
 
+void load_gdt_tss(cpu_data_t *core) {
+    // Load GDT
+    gdt_flush(&core->gdtr);
+
+    // Load TSS
+    tss_flush(0x28);  // Selector 0x28 (5th entry in GDT)
+}
+
 void init_all_gdt_tss() {
     int num_cores = detect_cores();  // Detect available CPU cores (e.g., via ACPI)
 
@@ -118,11 +122,7 @@ void core_init(int core) {
     // Get core-specific data
     cpu_data_t *data = &cpu_data[core];
 
-    // Load GDT
-    gdt_flush(&data->gdtr);
-
-    // Load TSS
-    tss_flush(0x28);  // Selector 0x28 (5th entry in GDT)
+    load_gdt_tss(data);
 
     // Set kernel stack in TSS
     // Michael Petch - this doesn't look right - bug???

--- a/src/x86_64/gdt/gdt.h
+++ b/src/x86_64/gdt/gdt.h
@@ -5,31 +5,22 @@
 #include <stdbool.h>
 
 
-struct gdt_entry
-{// 64-Bit
-    uint16_t limit_low;       // Lower 16 bits of the segment limit
-    uint16_t base_low;        // Lower 16 bits of the base address
-    uint8_t base_middle;      // Next 8 bits of the base address
-    uint8_t access;           // Access byte
-    uint8_t granularity;      // Flags and upper limit
-    uint8_t base_high;        // Next 8 bits of the base address
-}__attribute__((packed));
-typedef struct gdt_entry gdt_entry_t;
-
-struct tss_entry
-{// 128-Bit
-    uint16_t limit_low;       // Lower 16 bits of the segment limit
-    uint16_t base_low;        // Lower 16 bits of the base address
-    uint8_t base_middle;      // Next 8 bits of the base address
-    uint8_t access;           // Access byte
-    uint8_t granularity;      // Flags and upper limit
-    uint8_t base_high;        // Next 8 bits of the base address
-
-    uint32_t base_upper;     // Upper 32 bits of the base address (for 64-bit TSS)
-    uint32_t reserved;       // Reserved, must be zero
-}__attribute__((packed));
-typedef struct tss_entry tss_entry_t;
-
+union gdt_entry
+{   // 64-Bit
+    struct {
+        uint16_t limit_low;       // Lower 16 bits of the segment limit
+        uint16_t base_low;        // Lower 16 bits of the base address
+        uint8_t base_middle;      // Next 8 bits of the base address
+        uint8_t access;           // Access byte
+        uint8_t granularity;      // Flags and upper limit
+        uint8_t base_high;        // Next 8 bits of the base address
+    };
+    struct {
+        uint32_t base_upper;     // Upper 32 bits of the base address (for 64-bit TSS)
+        uint32_t reserved;       // Reserved, must be zero
+    };
+};
+typedef union gdt_entry gdt_entry_t;
 
 // Structure for GDTR
 struct gdtr {
@@ -49,15 +40,28 @@ struct tss{ // 9*64 = 576 bit = 72 byte = 0x48
     uint64_t ist1;  // Interrupt Stack Table (optional)
     uint64_t ist2;
     uint64_t ist3;
+    uint64_t ist4;
+    uint64_t ist5;
+    uint64_t ist6;
+    uint64_t ist7;
     uint64_t reserved2;
     uint16_t reserved3;
     uint16_t iopb_offset;
 } __attribute__((packed));
 typedef struct tss tss_t;
 
+#define GDT_ENTRIES_COUNT 7 // 5 GDT(64 Bit) + 1 TSS (128 Bit)
+typedef struct {
+    gdt_entry_t gdt[GDT_ENTRIES_COUNT];  // Each core's GDT
+    gdtr_t gdtr;
+    tss_t tss;                            // Core's Task State Segment
+    uint64_t kernel_stack;                // Kernel stack for Ring 0
+} cpu_data_t;
 
+void gdt_setup(gdt_entry_t gdt[], uint8_t idx, uint64_t base, uint32_t limit, uint8_t access, uint8_t granularity);
+void gdt_setup_sysseg(gdt_entry_t gdt[], uint8_t idx, uint64_t base, uint32_t limit, uint8_t access, uint8_t granularity);
 void start_bootstrap_gdt_tss();
-
+void init_gdt_tss(cpu_data_t *core);
 void init_all_gdt_tss();
 void core_init(int core);
 void start_secondary_cores();

--- a/src/x86_64/gdt/gdt.h
+++ b/src/x86_64/gdt/gdt.h
@@ -31,13 +31,13 @@ typedef struct gdtr gdtr_t;
 
 
 // Add TSS entry structure
-struct tss{ // 9*64 = 576 bit = 72 byte = 0x48
+struct tss{ // 104 bytes is the minimum size of a TSS
     uint32_t reserved0;
     uint64_t rsp0;  // Ring 0 Stack Pointer
     uint64_t rsp1;
     uint64_t rsp2;
     uint64_t reserved1;
-    uint64_t ist1;  // Interrupt Stack Table (optional)
+    uint64_t ist1;  // Interrupt Stack Entries
     uint64_t ist2;
     uint64_t ist3;
     uint64_t ist4;

--- a/src/x86_64/gdt/gdt.h
+++ b/src/x86_64/gdt/gdt.h
@@ -60,6 +60,7 @@ typedef struct {
 
 void gdt_setup(gdt_entry_t gdt[], uint8_t idx, uint64_t base, uint32_t limit, uint8_t access, uint8_t granularity);
 void gdt_setup_sysseg(gdt_entry_t gdt[], uint8_t idx, uint64_t base, uint32_t limit, uint8_t access, uint8_t granularity);
+void load_gdt_tss(cpu_data_t *core);
 void start_bootstrap_gdt_tss();
 void init_gdt_tss(cpu_data_t *core);
 void init_all_gdt_tss();


### PR DESCRIPTION
- Cleanup gdt.c by removing duplicate code
- Simplify code to use a union for `gdt_entry_t`
- The `tss_t` structure is missing members and is the wrong size